### PR TITLE
Fixes to two bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ pub:
 	@./ghp-url.sh ${NAME}
 
 clean: 
-	${RM} -r  ${OUTDIR}
+	${RM} -r  ${OUTDIR}/_build
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/ghp-nojekyll.sh
+++ b/ghp-nojekyll.sh
@@ -22,6 +22,7 @@ if ! git ls-tree  --name-only $branch 2> /dev/null | grep -q \.nojekyll ; then
      echo "ERROR: cannot switch to $branch ... please fix and retry"
      exit -1
    fi
+   cd .. && cd ..
    touch .nojekyll
    git add .nojekyll
    git commit -m "adding .nojekyll"


### PR DESCRIPTION
This will fix the two following bugs:

1. Make clean deleting the entire book rather than just the _build directory
2. The .nojekyll file being added to the wrong location. Currently it is being added to the wrong directory so when publishing the book the styling of the website is messed up.